### PR TITLE
summary of changes for tonight

### DIFF
--- a/Dynamic Asteroids/Data/Scripts/DynamicAsteroids/ZoneNetworkManager.cs
+++ b/Dynamic Asteroids/Data/Scripts/DynamicAsteroids/ZoneNetworkManager.cs
@@ -8,42 +8,68 @@ using System.Threading.Tasks;
 using VRage.Game.ModAPI;
 using VRageMath;
 
-namespace DynamicAsteroids.Data.Scripts.DynamicAsteroids {
-    public class ZoneNetworkManager {
+namespace DynamicAsteroids.Data.Scripts.DynamicAsteroids
+{
+    public class ZoneNetworkManager
+    {
         private Dictionary<long, HashSet<long>> _playerZoneAwareness = new Dictionary<long, HashSet<long>>();
-        private const double ZONE_AWARENESS_RADIUS = 25000; // Only sync zones within this range
+        private const double ZONE_AWARENESS_RADIUS = 25000;
 
-        public void UpdateZoneAwareness(
-            Dictionary<long, Vector3D> playerPositions,
-            ConcurrentDictionary<long, AsteroidZone> zones) {
-            foreach (var player in playerPositions) {
-                if (!_playerZoneAwareness.ContainsKey(player.Key)) {
-                    _playerZoneAwareness[player.Key] = new HashSet<long>();
+        public void UpdateZoneAwareness(Dictionary<long, Vector3D> playerPositions,
+            ConcurrentDictionary<long, AsteroidZone> zones)
+        {
+            // Clear old awareness data
+            _playerZoneAwareness.Clear();
+
+            // Build new awareness data
+            foreach (var playerKvp in playerPositions)
+            {
+                var playerPos = playerKvp.Value;
+                var playerid = playerKvp.Key;
+
+                // First, add player's own zone
+                var ownZone = zones.FirstOrDefault(z => z.Value.IsPointInZone(playerPos));
+                if (ownZone.Value != null)
+                {
+                    if (!_playerZoneAwareness.ContainsKey(playerid))
+                    {
+                        _playerZoneAwareness[playerid] = new HashSet<long>();
+                    }
+
+                    _playerZoneAwareness[playerid].Add(ownZone.Key);
+
+                    // Then check for merged zones
+                    foreach (var otherZone in zones)
+                    {
+                        if (otherZone.Key == ownZone.Key) continue;
+
+                        double distance = Vector3D.Distance(ownZone.Value.Center, otherZone.Value.Center);
+                        if (distance <= ownZone.Value.Radius + otherZone.Value.Radius)
+                        {
+                            _playerZoneAwareness[playerid].Add(otherZone.Key);
+                        }
+                    }
                 }
-
-                // Find zones this player should be aware of
-                var relevantZones = zones.Where(z =>
-                    Vector3D.Distance(player.Value, z.Value.Center) <= ZONE_AWARENESS_RADIUS);
-
-                _playerZoneAwareness[player.Key] = new HashSet<long>(relevantZones.Select(z => z.Key));
             }
         }
 
-        public void SendBatchedUpdates(List<AsteroidState> updates, ConcurrentDictionary<long, AsteroidZone> zones) {
-            if (updates == null || updates.Count == 0 || zones == null || zones.Count == 0) {
+        public void SendBatchedUpdates(List<AsteroidState> updates, ConcurrentDictionary<long, AsteroidZone> zones)
+        {
+            if (updates == null || updates.Count == 0 || zones == null || zones.Count == 0)
+            {
                 return;
             }
 
             // Group updates by zone
-            var updatesByZone = updates.GroupBy(u => {
+            var updatesByZone = updates.GroupBy(u =>
+            {
                 var zone = zones.FirstOrDefault(z => z.Value.IsPointInZone(u.Position));
                 return zone.Key;
-            }).Where(g => g.Key != 0); // Filter out updates with no zone
+            }).Where(g => g.Key != 0);
 
-            if (!updatesByZone.Any()) return;
-
-            foreach (var zoneGroup in updatesByZone) {
-                // Find players who should receive these updates
+            foreach (var zoneGroup in updatesByZone)
+            {
+                // Find players who should receive updates for this zone
                 var relevantPlayers = _playerZoneAwareness
                     .Where(p => p.Value.Contains(zoneGroup.Key))
                     .Select(p => p.Key)
@@ -51,33 +77,36 @@ namespace DynamicAsteroids.Data.Scripts.DynamicAsteroids {
 
                 if (relevantPlayers.Count == 0) continue;
 
-                // Send batched updates only to relevant players
+                // Send updates in batches
                 const int MAX_UPDATES_PER_PACKET = 25;
-                for (int i = 0; i < zoneGroup.Count(); i += MAX_UPDATES_PER_PACKET) {
+                for (int i = 0; i < zoneGroup.Count(); i += MAX_UPDATES_PER_PACKET)
+                {
                     var batch = zoneGroup.Skip(i).Take(MAX_UPDATES_PER_PACKET).ToList();
                     if (batch.Count == 0) continue;
 
                     var packet = new AsteroidBatchUpdatePacket();
                     packet.Updates.AddRange(batch);
-
                     byte[] data = MyAPIGateway.Utilities.SerializeToBinary(packet);
 
-                    // Send only to players who care about this zone
-                    foreach (var playerId in relevantPlayers) {
-                        var steamId = GetSteamId(playerId);
-                        if (steamId != 0) {
+                    foreach (var playerId in relevantPlayers)
+                    {
+                        var steamId = NetworkUtils.GetSteamId(playerId);
+                        if (steamId != 0)
+                        {
                             MyAPIGateway.Multiplayer.SendMessageTo(32000, data, steamId);
                         }
                     }
                 }
             }
         }
+    }
 
-        private ulong GetSteamId(long playerId) {
+    public static class NetworkUtils {
+        public static ulong GetSteamId(long playerId) {
             var players = new List<IMyPlayer>();
             MyAPIGateway.Players.GetPlayers(players);
             var player = players.FirstOrDefault(p => p.IdentityId == playerId);
-            return player?.SteamUserId ?? 0;
+            return player != null ? player.SteamUserId : 0;
         }
     }
 }


### PR DESCRIPTION
- Fixed duplicate entity ID issues on client reconnect by letting game handle ID assignment
- Added efficient asteroid lookup table to replace slow LINQ queries
- Improved zone merging logic and asteroid count tracking
- Fixed bug where zones only merged at centers instead of edges
- Added better client-server asteroid sync verification
- Added more comprehensive logging for debugging
- Improved memory management and cleanup routines
- Fixed issue where asteroids could appear on client but pass through (phantom asteroids)
- Optimized network traffic by only sending updates to relevant players
- Added proper zone tracking for merged zones
- Fixed C#6 compatibility issues
- Improved entity cleanup during client disconnects
- Better handling of asteroid removal during zone transitions

Performance improvements:
- Replaced inefficient IsAsteroidTracked LINQ query with O(1) dictionary lookup
- Reduced CPU usage during merged zone operations
- Optimized network bandwidth usage by zone-aware updates
- Reduced memory usage through better cleanup

Bug fixes:
- Fixed duplicate entity IDs during client reconnect
- Fixed phantom asteroids appearing on clients
- Fixed zone merging detection
- Fixed asteroid count inconsistencies between clients
- Fixed issues with merged zones exceeding asteroid limits